### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jekyll-docker.yml
+++ b/.github/workflows/jekyll-docker.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/Tanker187/open-vsx.org/security/code-scanning/1](https://github.com/Tanker187/open-vsx.org/security/code-scanning/1)

The fix is to explicitly restrict the `GITHUB_TOKEN` permissions in this workflow. Since the job only needs to read the repository contents (for `actions/checkout` and the build step), we can set `contents: read` as the minimal permission. We add a `permissions` block at the workflow root (top level) so it applies to all jobs, and we keep it as restrictive as possible.

Concretely, edit `.github/workflows/jekyll-docker.yml` to insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block (i.e., after line 7 and before line 9). No other functionality changes are required, and no additional imports or methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
