### PR TITLE
Potential fix for code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/website/dev/server/index.js
+++ b/website/dev/server/index.js
@@ -10,11 +10,19 @@
 
 const express = require('express');
 const path = require('path');
+const RateLimit = require('express-rate-limit');
 
 const port = 3000;
 const staticPath = path.join(__dirname, '..', '..', 'static');
 
 const app = express();
+
+const limiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+});
+
+app.use(limiter);
 
 app.use(express.static(path.join(__dirname, '..', 'static')));
 app.use(express.static(staticPath));

--- a/website/package.json
+++ b/website/package.json
@@ -6,7 +6,8 @@
     "repository": "https://github.com/eclipse/open-vsx.org",
     "license": "EPL-2.0",
     "dependencies": {
-        "openvsx-webui": "0.16.4"
+        "openvsx-webui": "0.16.4",
+        "express-rate-limit": "^8.2.1"
     },
     "devDependencies": {
         "@types/markdown-it": "^12.2.3",


### PR DESCRIPTION
Potential fix for [https://github.com/Tanker187/open-vsx.org/security/code-scanning/5](https://github.com/Tanker187/open-vsx.org/security/code-scanning/5)

To fix the problem, add an Express rate-limiting middleware and apply it to the relevant routes before they reach the handler that calls `res.sendFile`. The standard approach is to use a well-known library such as `express-rate-limit`, configure reasonable defaults (e.g., a number of requests per time window), and register the middleware with `app.use(...)` so it protects all routes, or specifically `app.get('*', ...)` if we only want to guard that handler.

In this file (`website/dev/server/index.js`), the minimal change without altering existing functionality is:
- Import `express-rate-limit`.
- Create a limiter instance (e.g., 100 requests per 15 minutes per IP).
- Apply `app.use(limiter);` before static middlewares and the catch-all route.  

No existing logic needs to change; we only prepend the middleware configuration. Concretely:
- At the top of the file, after existing `require` statements, add `const RateLimit = require('express-rate-limit');`.
- After `const app = express();`, define `const limiter = RateLimit({...});` with chosen settings.
- Add `app.use(limiter);` before `app.use(express.static(...))` so that all requests, including static file serving and the `app.get('*', ...)` route, are rate-limited.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
