### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,9 @@
 
 name: Node.js Package
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [created]


### PR DESCRIPTION
Potential fix for [https://github.com/Tanker187/open-vsx.org/security/code-scanning/7](https://github.com/Tanker187/open-vsx.org/security/code-scanning/7)

To fix the problem, explicitly define a minimal `permissions` block so that the GITHUB_TOKEN has only the access required. Here, neither job interacts with the repository through GITHUB_TOKEN; they only check out code and publish to npm using `NODE_AUTH_TOKEN`. Therefore, `contents: read` is sufficient. The cleanest way is to add a workflow-level `permissions` block so both `build` and `publish-npm` jobs inherit it.

Concretely, in `.github/workflows/npm-publish.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: Node.js Package` and `on:` lines (around line 6). This will apply to all jobs in the workflow without changing their behavior. No additional imports or other code changes are required, and this keeps the functionality intact while constraining the default GITHUB_TOKEN permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
